### PR TITLE
added feedback proxy feature

### DIFF
--- a/apns_proxy_server/feedback.py
+++ b/apns_proxy_server/feedback.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import time
+
+from apns import APNs
+import simplejson as json
+
+
+class FeedbackProxy(object):
+    def __init__(self, use_sandbox, cert_file, key_file):
+        self.use_sandbox = use_sandbox
+        self.cert_file = cert_file
+        self.key_file = key_file
+
+        self._apns = APNs(
+            use_sandbox=self.use_sandbox,
+            cert_file=self.cert_file,
+            key_file=self.key_file,
+        )
+
+    def get(self):
+        conn = self._apns.feedback_server
+        result = {}
+
+        for item in conn.items():
+            token, datetime = item
+            result[token] = time.mktime(datetime.timetuple())
+
+        return json.dumps(result)

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for apns_proxy_server.feedback
+"""
+
+from datetime import datetime
+
+from nose.tools import ok_, eq_
+import simplejson as json
+
+from apns_proxy_server.feedback import FeedbackProxy
+
+
+def test_instance():
+    proxy = FeedbackProxy(True, '/path/to/cert', '/path/to/key')
+    ok_(proxy)
+    ok_(proxy.use_sandbox)
+    eq_(proxy.cert_file, '/path/to/cert')
+    eq_(proxy.key_file, '/path/to/key')
+
+
+def test_get():
+    disabled_datetime = datetime(1988, 4, 23, 2, 0, 0)
+
+    proxy = FeedbackProxy(True, '/path/to/cert', '/path/to/key')
+    proxy._apns = type('MockApns', (object,), {
+        'feedback_server': {
+            'token_value': disabled_datetime,
+        },
+    })
+
+    result = proxy.get()
+    json_result = json.loads(result)
+
+    ok_(result)
+    ok_(json_result)
+    ok_(isinstance(result, basestring))
+    ok_(isinstance(json_result, dict))
+
+    ok_('token_value' in json_result)
+    eq_(datetime.fromtimestamp(json_result['token_value']), disabled_datetime)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,19 +32,22 @@ def test_instance():
 
 def test_create_worker():
     server = APNSProxyServer(dummy_setting)
-    server.create_workers([{
-        "application_id": "myApp1",
-        "name": "My App1",
-        "sandbox": False,
-        "cert_file": "sample.cert",
-        "key_file": "sample.key"
-    }, {
-        "application_id": "myApp2",
-        "name": "My App2",
-        "sandbox": False,
-        "cert_file": "sample.cert",
-        "key_file": "sample.key"
-    }], 1)
+    server.create_workers({
+        "myApp1": {
+            "application_id": "myApp1",
+            "name": "My App1",
+            "sandbox": False,
+            "cert_file": "sample.cert",
+            "key_file": "sample.key"
+        },
+        "myApp2": {
+            "application_id": "myApp2",
+            "name": "My App2",
+            "sandbox": False,
+            "cert_file": "sample.cert",
+            "key_file": "sample.key"
+        },
+    }, 1)
     eq_(len(server.task_queues), 2)
     for k in server.task_queues.keys():
         ok_(isinstance(server.task_queues[k], Queue))
@@ -52,19 +55,22 @@ def test_create_worker():
 
 def test_dispatch_known_app():
     server = APNSProxyServer(dummy_setting)
-    server.create_workers([{
-        "application_id": "myApp1",
-        "name": "My App1",
-        "sandbox": False,
-        "cert_file": "sample.cert",
-        "key_file": "sample.key"
-    }, {
-        "application_id": "myApp2",
-        "name": "My App2",
-        "sandbox": False,
-        "cert_file": "sample.cert",
-        "key_file": "sample.key"
-    }], 1)
+    server.create_workers({
+        "myApp1": {
+            "application_id": "myApp1",
+            "name": "My App1",
+            "sandbox": False,
+            "cert_file": "sample.cert",
+            "key_file": "sample.key"
+        },
+        "myApp2": {
+            "application_id": "myApp2",
+            "name": "My App2",
+            "sandbox": False,
+            "cert_file": "sample.cert",
+            "key_file": "sample.key"
+        },
+    }, 1)
 
     token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     eq_(server.dispatch_queue(json.dumps({
@@ -94,13 +100,15 @@ def test_dispatch_known_app():
 
 def test_dispatch_unknown_app():
     server = APNSProxyServer(dummy_setting)
-    server.create_workers([{
-        "application_id": "myApp2",
-        "name": "My App2",
-        "sandbox": False,
-        "cert_file": "sample.cert",
-        "key_file": "sample.key"
-    }], 1)
+    server.create_workers({
+        "myApp2": {
+            "application_id": "myApp2",
+            "name": "My App2",
+            "sandbox": False,
+            "cert_file": "sample.cert",
+            "key_file": "sample.key"
+        },
+    }, 1)
 
     token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     eq_(server.dispatch_queue(json.dumps({
@@ -118,13 +126,15 @@ def test_dispatch_unknown_app():
 
 def test_dispatch_messages():
     server = APNSProxyServer(dummy_setting)
-    server.create_workers([{
-        "application_id": "myApp2",
-        "name": "My App2",
-        "sandbox": False,
-        "cert_file": "sample.cert",
-        "key_file": "sample.key"
-    }], 1)
+    server.create_workers({
+        "myApp2": {
+            "application_id": "myApp2",
+            "name": "My App2",
+            "sandbox": False,
+            "cert_file": "sample.cert",
+            "key_file": "sample.key"
+        },
+    }, 1)
 
     token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     eq_(server.dispatch_queue(json.dumps({
@@ -147,6 +157,34 @@ def test_dispatch_messages():
         })), True)
 
 
+def test_get_feedback():
+    server = APNSProxyServer(dummy_setting)
+    server.app_config["myApp1"] = {
+        "application_id": "myApp1",
+        "name": "My App1",
+        "sandbox": True,
+        "cert_file": "sample.cert",
+        "key_file": "sample.key",
+    }
+
+    proxy = server.get_feedback_proxy(json.dumps({
+        "appid": "myApp1",
+    }))
+    ok_(proxy)
+    ok_(proxy.use_sandbox)
+    eq_(proxy.cert_file, "sample.cert")
+    eq_(proxy.key_file, "sample.key")
+
+
+def test_get_feedback_with_unknown_app():
+    server = APNSProxyServer(dummy_setting)
+
+    proxy = server.get_feedback_proxy(json.dumps({
+        "appid": "myApp1",
+    }))
+    ok_(not proxy)
+
+
 def test_thread_count():
     """
     スレッド生成数のテスト
@@ -154,19 +192,22 @@ def test_thread_count():
     before_num = threading.active_count()
 
     server = APNSProxyServer(dummy_setting)
-    server.create_workers([{
-        "application_id": "myApp1",
-        "name": "My App1",
-        "sandbox": False,
-        "cert_file": "sample.cert",
-        "key_file": "sample.key"
-    }, {
-        "application_id": "myApp2",
-        "name": "My App2",
-        "sandbox": False,
-        "cert_file": "sample.cert",
-        "key_file": "sample.key"
-    }], 3)
+    server.create_workers({
+        "myApp1": {
+            "application_id": "myApp1",
+            "name": "My App1",
+            "sandbox": False,
+            "cert_file": "sample.cert",
+            "key_file": "sample.key"
+        },
+        "myApp2": {
+            "application_id": "myApp2",
+            "name": "My App2",
+            "sandbox": False,
+            "cert_file": "sample.cert",
+            "key_file": "sample.key"
+        },
+    }, 3)
 
     after_num = threading.active_count()
 


### PR DESCRIPTION
now server accepts `\3{"app_id": "xxxxx"}` command as getting device tokens from feedback server
- The current implementation of this feature stores full list of device tokens to server memory and dump it as response. We should change do that as streaming for large feedback list
- Change the internal APNSProxyServer.app_config format from list to dict (settings['APPLICATIONS'] is not changed)
